### PR TITLE
exclude migrations from pycodestyle

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pycodestyle]
+exclude = migrations


### PR DESCRIPTION
migrations are auto-generated and code style is not important for them.